### PR TITLE
(feat) Add reserve method. Change capacity to char utins instead bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ An efficient dynamically sized string buffer (aka **String Builder**) for Assemb
 class StringSink {
   static withCapacity(capacity: i32)
 
-  constructor(initial: string = "", capacity: i32 = 64)
+  constructor(initial: string = "", capacity: i32 = 32)
 
   get length(): i32
   get capacity(): i32
@@ -20,6 +20,7 @@ class StringSink {
   writeLn(src: string, start?: i32, end?: i32): void
   writeCodePoint(code: i32): void
 
+  reserve(capacity: i32): void
   shrink(): void
   clear(): void
 

--- a/assembly/__tests__/general.spec.ts
+++ b/assembly/__tests__/general.spec.ts
@@ -4,22 +4,22 @@ describe("general", () => {
   it("default constructor", () => {
     let sink = new StringSink;
     expect(sink.length).toBe(0);
-    expect(sink.capacity).toBe(64); // default
+    expect(sink.capacity).toBe(32); // default
     expect(sink.toString()).toBe("");
   });
 
   it("initial constructor", () => {
     let sink = new StringSink("hello");
     expect(sink.length).toBe(5);
-    expect(sink.capacity).toBe(64); // default
+    expect(sink.capacity).toBe(32); // default
     expect(sink.toString()).toBe("hello");
   });
 
   it("capacity constructor", () => {
-    let sink = StringSink.withCapacity(128);
+    let sink = StringSink.withCapacity(64);
     sink.write("hello")
     expect(sink.length).toBe(5);
-    expect(sink.capacity).toBe(128);
+    expect(sink.capacity).toBe(64);
     expect(sink.toString()).toBe("hello");
   });
 
@@ -27,7 +27,7 @@ describe("general", () => {
     let sink = new StringSink;
     sink.write("hello");
     expect(sink.length).toBe(5);
-    expect(sink.capacity).toBe(64); // default
+    expect(sink.capacity).toBe(32); // default
     expect(sink.toString()).toBe("hello");
   });
 
@@ -35,7 +35,7 @@ describe("general", () => {
     let sink = new StringSink("hello");
     sink.write(" world!");
     expect(sink.length).toBe(12);
-    expect(sink.capacity).toBe(64); // default
+    expect(sink.capacity).toBe(32); // default
     expect(sink.toString()).toBe("hello world!");
   });
 
@@ -43,7 +43,7 @@ describe("general", () => {
     let sink = new StringSink("hello");
     sink.write("_world", 1, 3);
     expect(sink.length).toBe(7);
-    expect(sink.capacity).toBe(64); // default
+    expect(sink.capacity).toBe(32); // default
     expect(sink.toString()).toBe("hellowo");
   });
 
@@ -51,7 +51,7 @@ describe("general", () => {
     let sink = new StringSink("hello");
     sink.write(" world!", -1, 3);
     expect(sink.length).toBe(8);
-    expect(sink.capacity).toBe(64); // default
+    expect(sink.capacity).toBe(32); // default
     expect(sink.toString()).toBe("hello wo");
   });
 
@@ -59,7 +59,7 @@ describe("general", () => {
     let sink = new StringSink("hello");
     sink.write(" world!", 4, -5);
     expect(sink.length).toBe(9);
-    expect(sink.capacity).toBe(64); // default
+    expect(sink.capacity).toBe(32); // default
     expect(sink.toString()).toBe("hello wor");
   });
 
@@ -67,7 +67,7 @@ describe("general", () => {
     let sink = new StringSink("hello");
     sink.write(" world!", 0, -2);
     expect(sink.length).toBe(5);
-    expect(sink.capacity).toBe(64); // default
+    expect(sink.capacity).toBe(32); // default
     expect(sink.toString()).toBe("hello");
   });
 
@@ -79,7 +79,7 @@ describe("general", () => {
       str += " stub ";
     }
     expect(sink.length).toBe(6 * 16);    // 96
-    expect(sink.capacity).toBe(128 * 2); // nextPOT(96) -> 128
+    expect(sink.capacity).toBe(128); // nextPOT(96) -> 128
     expect(sink.toString()).toBe(str);
   });
 
@@ -88,7 +88,7 @@ describe("general", () => {
     sink.writeLn("hello");
     sink.writeLn("world");
     expect(sink.length).toBe(12);
-    expect(sink.capacity).toBe(64); // default
+    expect(sink.capacity).toBe(32); // default
     expect(sink.toString()).toBe("hello\nworld\n");
   });
 
@@ -115,34 +115,48 @@ describe("general", () => {
     expect(sink.toString()).toBe(spaces + "fire:🔥");
   });
 
-  it("clear for less than 64 bytes capacity", () => {
+  it("clear for less than 32 lenght capacity", () => {
     let sink = new StringSink("hello");
     sink.clear();
     expect(sink.length).toBe(0);
-    expect(sink.capacity).toBe(64);
+    expect(sink.capacity).toBe(32);
   });
 
-  it("clear for more than 64 bytes capacity", () => {
+  it("clear for more than 32 lenght capacity", () => {
     let sink = new StringSink(" ".repeat(64));
     sink.clear();
     expect(sink.length).toBe(0);
-    expect(sink.capacity).toBe(64);
+    expect(sink.capacity).toBe(32);
   });
 
-  it("shrink for less than 64 bytes capacity", () => {
+  it("shrink for less than 32 lenght capacity", () => {
     let sink = new StringSink("hello");
     sink.shrink();
     expect(sink.length).toBe(5);
-    expect(sink.capacity).toBe(64);
+    expect(sink.capacity).toBe(32);
   });
 
-  it("shrink for more than 64 bytes capacity", () => {
+  it("shrink for more than 32 lenght capacity", () => {
     let sink = new StringSink(" ".repeat(33));
     expect(sink.length).toBe(33);
-    expect(sink.capacity).toBe(33 * 2);
+    expect(sink.capacity).toBe(33);
 
     sink.shrink();
     expect(sink.length).toBe(33);
-    expect(sink.capacity).toBe(33 * 2);
+    expect(sink.capacity).toBe(33);
+  });
+
+  it("reserve less than length", () => {
+    let sink = new StringSink("hello");
+    sink.reserve(2);
+    expect(sink.capacity).toBe(32);
+    expect(sink.toString()).toBe("hello");
+  });
+
+  it("reserve more than length", () => {
+    let sink = new StringSink("hello");
+    sink.reserve(300);
+    expect(sink.capacity).toBe(300);
+    expect(sink.toString()).toBe("hello");
   });
 });


### PR DESCRIPTION
- Add new instance method `reserve`. Fix #8
- Change units for `capacity` property from `bytes` to `chars`